### PR TITLE
Rename RO_GH_TOKEN to be clearer what it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The following defaults will be used if omitted in `.bumper.json`:
     "vcs": {
       "domain": "github.com",
       "env": {
-        "readToken": "RO_GH_TOKEN",
+        "readToken": "GITHUB_READ_ONLY_TOKEN",
         "writeToken": "GITHUB_TOKEN"
       },
       "provider": "github",
@@ -346,12 +346,12 @@ While one can access the GitHub API just fine without a token, there are rate-li
 Since those rate-limits are based on the IP of the requester, you'd be sharing a limit with anyone else building in
 your CI, which, for Travis CI, could be quite a few people. So, if you specify a `vcs.env.readToken` and
 set the corresponding environment variable in your CI environment, `bumpr` will use that token when making API
-requests to find out information about pull requests. Since we need to be able to access `RO_GH_TOKEN` during a PR
-build, it cannot be encrypted, and thus will not be private. See [travis docs][env-docs] for more info about encrypted
-environment variables.
+requests to find out information about pull requests. Since we need to be able to access `GITHUB_READ_ONLY_TOKEN`
+during a PR build, it cannot be encrypted, and thus will not be private. See [travis docs][env-docs] for more info
+about encrypted environment variables.
 
-> **NOTE** Since `RO_GH_TOKEN` is not secure, it is printed directly into your Travis Logs!!!
-> So, make sure it has only read access to your repository. Hence the name `RO_GH_TOKEN` (Read Only GitHub Token)
+> **NOTE** Since `GITHUB_READ_ONLY_TOKEN` is not secure, it is printed directly into your Travis Logs!!!
+> So, make sure it has only read access to your repository. Hence the name `GITHUB_READ_ONLY_TOKEN`
 
 ##### `vcs.env.writeToken`
 The name of the environment variable that holds the write access token to use when pushing commits to your vcs

--- a/src/__tests__/utils-test.js
+++ b/src/__tests__/utils-test.js
@@ -154,7 +154,7 @@ describe('utils', () => {
         env = {
           TRAVIS_BRANCH: 'my-branch',
           TRAVIS_BUILD_NUMBER: '123',
-          RO_GH_TOKEN: '12345',
+          GITHUB_READ_ONLY_TOKEN: '12345',
           GITHUB_TOKEN: '54321'
         }
       })

--- a/src/utils.js
+++ b/src/utils.js
@@ -168,7 +168,7 @@ const utils = {
       vcs: {
         domain: 'github.com',
         env: {
-          readToken: 'RO_GH_TOKEN',
+          readToken: 'GITHUB_READ_ONLY_TOKEN',
           writeToken: 'GITHUB_TOKEN'
         },
         provider: 'github',

--- a/src/vcs/github.js
+++ b/src/vcs/github.js
@@ -13,7 +13,7 @@ const {exec} = require('../node-wrappers')
 function getFetchOpts(config) {
   const {readToken} = config.computed.vcs.auth
   const headers = {}
-  Logger.log(`RO_GH_TOKEN = [${readToken}]`)
+  Logger.log(`GITHUB_READ_ONLY_TOKEN = [${readToken}]`)
   if (readToken) {
     headers.Authorization = `token ${readToken}`
   }


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Please add a description of your change below.
It will be automatically inserted into the `CHANGELOG.md` file.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
Please remove sections that doesn't apply to your change.

## CHANGELOG
### Changed
- Default read-only github token env variable from `RO_GH_TOKEN` to `GITHUB_READ_ONLY_TOKEN`. Technically a breaking change, but since 1.x was only released yesterday, I think we're OK. 
