### PR TITLE
Add slack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,13 @@ The following defaults will be used if omitted in `.bumper.json`:
       "logging": {
         "enabled": false,
         "file": "bumpr-log.json"
+      },
+      "slack": {
+        "enabled": false,
+        "env": {
+          "url": "SLACK_URL"
+        },
+        "channels": []
       }
     },
     "files": ['package.json'],
@@ -348,6 +355,27 @@ Set this value to `true` to enable the creation of the log file during a `bump`.
 ##### `features.logging.file`
 The name of the file to create after a `bump`, the contents of the file will be `json` regardless of the name of
 the file given here.
+
+#### `features.slack`
+Send a message in slack detailing the change that `bumpr` just published. The message will be sent after the `publish`
+command completes.
+
+- `changelog` - The full text of the changelog that was added during this `bump`
+- `pr.number` - The pull request number that was merged for this `bump`
+- `pr.url` - The URL for the pull request that was merged for this `bump`
+- `scope` - the scope of the `bump` performed
+- `version` - the new version after the `bump`
+
+##### `features.slack.enabled`
+Set this value to `true` to enable the sending of slack messages after publish
+
+##### `features.slack.env.url`
+The name of the environment variable that holds the URL for your slack webhook.
+
+##### `features.slack.channels`
+An array of channels. The message will be sent to each one individually, using the `channel` property in the slack
+message JSON body. If no channels are given, only a single message will be sent, with no `channel` property, and so
+the default channel for the webhook will be used.
 
 ### `vcs`
 Holds all the information `bumpr` needs to interact with your version control system.

--- a/src/__tests__/utils-test.js
+++ b/src/__tests__/utils-test.js
@@ -155,7 +155,8 @@ describe('utils', () => {
           TRAVIS_BRANCH: 'my-branch',
           TRAVIS_BUILD_NUMBER: '123',
           GITHUB_READ_ONLY_TOKEN: '12345',
-          GITHUB_TOKEN: '54321'
+          GITHUB_TOKEN: '54321',
+          SLACK_URL: 'slack-webhook-url'
         }
       })
 
@@ -184,7 +185,7 @@ describe('utils', () => {
         })
       })
 
-      describe('when doing a merge build (w/o coverage in package.json)', () => {
+      describe('when doing a merge build', () => {
         beforeEach(() => {
           env.TRAVIS_PULL_REQUEST = 'false'
 
@@ -209,7 +210,7 @@ describe('utils', () => {
         })
       })
 
-      describe('when doing a merge build', () => {
+      describe('when doing a merge build (with slack feature enabled)', () => {
         beforeEach(() => {
           env.TRAVIS_PULL_REQUEST = 'false'
 
@@ -217,20 +218,17 @@ describe('utils', () => {
           setEnv(env)
 
           // '.pr-bumper.json'
-          mockJSONFileRead(new Error())
+          mockJSONFileRead({
+            features: {
+              slack: {enabled: true}
+            }
+          })
 
           ctx.config = utils.getConfig()
         })
 
-        verifyGitHubTravisDefaults(ctx)
-        verifyFeatureDefaults(ctx)
-
-        it('should set isPr to false', () => {
-          expect(ctx.config.computed.ci.isPr).toBe(false)
-        })
-
         it('should set prNumber to false', () => {
-          expect(ctx.config.computed.ci.prNumber).toBe('false')
+          expect(ctx.config.computed.slackUrl).toBe('slack-webhook-url')
         })
       })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,6 +95,11 @@ function processEnv(config) {
   config.computed.ci.isPr = config.computed.ci.prNumber !== 'false'
   config.computed.ci.branch = getEnv(config.ci.env.branch, 'master')
 
+  // Grab slack URL from env (if feature enabled)
+  if (config.features.slack.enabled) {
+    config.computed.slackUrl = getEnv(config.features.slack.env.url)
+  }
+
   Logger.log(`bumpr::config: prNumber [${config.computed.ci.prNumber}], isPr [${config.computed.ci.isPr}]`)
 
   // Grab the VCS stuff from the env
@@ -162,6 +167,13 @@ const utils = {
         logging: {
           enabled: false,
           file: 'bumpr-log.json'
+        },
+        slack: {
+          enabled: false,
+          env: {
+            url: 'SLACK_URL'
+          },
+          channels: []
         }
       },
       files: ['package.json'],

--- a/src/vcs/github.js
+++ b/src/vcs/github.js
@@ -13,7 +13,6 @@ const {exec} = require('../node-wrappers')
 function getFetchOpts(config) {
   const {readToken} = config.computed.vcs.auth
   const headers = {}
-  Logger.log(`GITHUB_READ_ONLY_TOKEN = [${readToken}]`)
   if (readToken) {
     headers.Authorization = `token ${readToken}`
   }


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Please add a description of your change below.
It will be automatically inserted into the `CHANGELOG.md` file.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
Please remove sections that doesn't apply to your change.

## CHANGELOG
### Added
- `slack` feature, which allows sending a slack message to a configured set of channels after a `publish` command is executed. Since this only affects `publish`, it only works when `logging` is also configured. You specify the URL for the slack webhook in an environment variable (default `SLACK_URL`. 
