### PR TITLE
Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ The following defaults will be used if omitted in `.bumperrc.js`:
           url: 'SLACK_URL'
         },
         channels: []
+      },
+      timezone: {
+        enabled: false,
+        zone: 'Etc/UTC'
       }
     },
     files: ['package.json'],
@@ -379,6 +383,19 @@ The name of the environment variable that holds the URL for your slack webhook.
 An array of channels. The message will be sent to each one individually, using the `channel` property in the slack
 message JSON body. If no channels are given, only a single message will be sent, with no `channel` property, and so
 the default channel for the webhook will be used.
+
+#### `features.timezone`
+Report dates in changelog based on a given timezone. By default, `bumpr` uses the UTC timezone to figure out what
+date a version is being published. When enabled, this feature allows you to configure a timezone to use to determine
+the date.
+
+##### `features.timezone.enabled`
+Set this value to `true` to enable overriding the timezone used by `bumpr` when computing the date string to add into
+your changelog.
+
+##### `features.timezone.zone`
+The timezone to use. You can use any time zone name supported by [`moment-timezone`](https://momentjs.com/timezone/).
+For example, `America/Los_Angeles`, `America/Denver`, or `America/New_York`
 
 ### `vcs`
 Holds all the information `bumpr` needs to interact with your version control system.

--- a/README.md
+++ b/README.md
@@ -343,7 +343,11 @@ The log file that will be created will look something like this:
   "changelog": "### Added\n- Some cool new feature",
   "pr": {
     "number": 123,
-    "url": "https://github.com/jobsquad/bumpr/pull/123"
+    "url": "https://github.com/jobsquad/bumpr/pull/123",
+    "user": {
+      "login": "job13er",
+      "url": "https://github.com/job13er"
+    },
   },
   "scope": "minor",
   "version": "1.3.0"
@@ -353,7 +357,10 @@ The log file that will be created will look something like this:
 - `changelog` - The full text of the changelog that was added during this `bump`
 - `pr.number` - The pull request number that was merged for this `bump`
 - `pr.url` - The URL for the pull request that was merged for this `bump`
+- `pr.user.login` - The username of the user who created the pull request that was merged for this `bump`
+- `pr.user.url` - The profile URL of the user who created the pull request that was merged for this `bump`
 - `scope` - the scope of the `bump` performed
+- `user.login` - the scope of the `bump` performed
 - `version` - the new version after the `bump`
 
 ##### `features.logging.enabled`

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "commander": "^2.9.0",
     "cosmiconfig": "^5.0.5",
     "lodash": "^4.0.1",
+    "moment-timezone": "^0.5.21",
     "nlf": "^1.4.1",
     "node-fetch": "^1.3.3",
     "promise": "^7.1.1",

--- a/src/bumpr.js
+++ b/src/bumpr.js
@@ -193,6 +193,8 @@ class Bumpr {
       const getChangelog = this.config.isEnabled('changelog') && scope !== 'none'
 
       return {
+        author: pr.author,
+        authorUrl: pr.authorUrl,
         changelog: getChangelog ? utils.getChangelogForPr(pr) : '',
         modifiedFiles: [],
         number: pr.number,
@@ -326,9 +328,21 @@ class Bumpr {
       Logger.log('Skipping logging because of config option.')
       return Promise.resolve(info)
     }
+    const {author, authorUrl, changelog, number, scope, url, version} = info
 
-    const logInfo = cloneDeep(info)
-    delete logInfo.modifiedFiles
+    const logInfo = {
+      changelog,
+      pr: {
+        number,
+        url,
+        user: {
+          login: author,
+          url: authorUrl
+        }
+      },
+      scope,
+      version
+    }
 
     const filename = this.config.features.logging.file
     Logger.log(`Writing ${JSON.stringify(logInfo)} to ${filename}`)
@@ -394,15 +408,16 @@ class Bumpr {
    * @param {Object} log - the already read log
    * @returns {Promise} the promise that resolves when slack messages have sent or rejects on error
    */
-  maybeSendSlackMessage({number, url, scope, version}) {
+  maybeSendSlackMessage({pr, scope, version}) {
     if (!this.config.isEnabled('slack')) {
       Logger.log('Skipping sending slack message because of config option.')
       return Promise.resolve()
     }
-
+    const {number, url, user} = pr
     const {slackUrl} = this.config.computed
     const pkg = utils.readJsonFile('package.json')
-    const message = `Published \`${pkg.name}@${version}\` from <${url}|PR #${number}> (${scope})`
+    const pkgStr = `${pkg.name}@${version}`
+    const message = `Published \`${pkgStr}\` (${scope}) from <${url}|PR #${number}> by <${user.url}|${user.login}>`
 
     const {channels} = this.config.features.slack
     if (channels.length === 0) {

--- a/src/bumpr.js
+++ b/src/bumpr.js
@@ -1,7 +1,8 @@
 require('./typedefs')
 
 const chalk = require('chalk')
-const {cloneDeep, find, get} = require('lodash')
+const {cloneDeep, get} = require('lodash')
+const moment = require('moment-timezone')
 const fetch = require('node-fetch')
 const Promise = require('promise')
 const replace = require('replace-in-file')
@@ -350,12 +351,14 @@ class Bumpr {
       return Promise.resolve(info)
     }
 
-    const now = new Date()
-    const dateString = now
-      .toISOString()
-      .split('T')
-      .slice(0, 1)
-      .join('')
+    let timezone = 'Etc/UTC'
+    if (this.config.isEnabled('timezone')) {
+      timezone = this.config.features.timezone.zone
+    }
+
+    const dateString = moment()
+      .tz(timezone)
+      .format('YYYY-MM-DD')
 
     const prLink = `[PR ${info.number}](${info.url})`
     const data = `<!-- bumpr -->\n\n## [${info.version}] - ${dateString} (${prLink})\n${info.changelog}`

--- a/src/bumpr.js
+++ b/src/bumpr.js
@@ -171,20 +171,10 @@ class Bumpr {
    * @returns {PrPromise} a promise resolved with the most recent PR
    */
   getLastPr() {
-    return exec('git log -10 --oneline').then(stdout => {
-      // the --oneline format for `git log` puts each commit on a single line, with the hash and then
-      // the commit message, so we first split on \n to get an array of commits
-      const commits = stdout.split('\n')
-
-      // The commit that represents the merging of the PR will include the text 'pull request #' so
-      // we find that one
-      const mergeCommit = find(commits, commit => commit.match('pull request #') !== null)
-
-      // Get the number from the PR commit
-      const prNumber = mergeCommit.match(/pull request #(\d*)/)[1]
-
-      Logger.log(`Fetching PR [${prNumber}]`)
-      return this.vcs.getPr(prNumber)
+    return exec('git rev-list HEAD --max-count=1').then(stdout => {
+      const sha = stdout.trim()
+      Logger.log(`Fetching PR for sha [${sha}]`)
+      return this.vcs.getMergedPrBySha(sha)
     })
   }
 

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -127,7 +127,6 @@
  * @property {Number} number - the PR #
  * @property {String} description - the description of the PR
  * @property {String} url - the URL for the web interface of the PR
- * @property {String} headCommitSha - SHA for the head commit of the incoming branch for the PR
  */
 
 /**

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -109,13 +109,22 @@
  */
 
 /**
+ * The representation of a user on github
+ * @typedef GitHubUser
+ * @property {String} login - username
+ * @property {String} html_url - profile url
+ */
+
+/**
  * The shape of the PR pulled from GitHub's `/repos/:owner/:repo/pulls` API
  * {@link https://developer.github.com/v3/pulls/}
  *
  * @typedef GitHubPullRequest
  * @property {Number} number - the PR #
  * @property {String} body - the description of the PR
+ * @property {GitHubUser} user - the user who opened the PR
  * @property {String} html_url - the URL for the web interface of the PR
+ * @property {String} merge_commit_sha - sha of the merge commit
  * @property {GitHubCommit} head - representation of the tip commit from the branch being merged
  * @property {GitHubCommit} base - representation of the tip commit from the branch being merged into
  */
@@ -127,12 +136,16 @@
  * @property {Number} number - the PR #
  * @property {String} description - the description of the PR
  * @property {String} url - the URL for the web interface of the PR
+ * @property {String} author - username of the PR author
+ * @property {String} authorUrl - URL of the PR author's profile
  */
 
 /**
  * Generic Pull Request info (used for updating package.json and CHANGELOG.md files)
  *
  * @typedef PrInfo
+ * @property {String} author - the username of the PR author
+ * @property {String} authorUrl - the profile URL of the PR author
  * @property {String} changelog - the changelog text
  * @property {Number} number - the PR #
  * @property {String} scope - the scope of the PR

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,6 +178,10 @@ const utils = {
                 url: 'SLACK_URL'
               },
               channels: []
+            },
+            timezone: {
+              enabled: false,
+              zone: 'Etc/UTC'
             }
           },
           files: ['package.json'],

--- a/src/vcs/github.js
+++ b/src/vcs/github.js
@@ -30,8 +30,10 @@ function convertLineEndings(str) {
  */
 function convertPr(ghPr) {
   return {
-    number: ghPr.number,
+    author: ghPr.user.login,
+    authorUrl: ghPr.user.html_url,
     description: convertLineEndings(ghPr.body),
+    number: ghPr.number,
     url: ghPr.html_url
   }
 }

--- a/src/vcs/github.js
+++ b/src/vcs/github.js
@@ -32,8 +32,7 @@ function convertPr(ghPr) {
   return {
     number: ghPr.number,
     description: convertLineEndings(ghPr.body),
-    url: ghPr.html_url,
-    headSha: ghPr.head.sha
+    url: ghPr.html_url
   }
 }
 
@@ -66,6 +65,32 @@ class GitHub {
     // TODO: find a safer way to do this, as the token can be displayed if a bug
     // is introduced here and exec errors out.
     return exec(`git remote add ci-origin https://${ghToken}@github.com/${owner}/${name}`).then(() => 'ci-origin')
+  }
+
+  /**
+   * Get the merged PR by the given sha
+   * @param {String} sha - the merge_commit_sha of the PR
+   * @returns {Promise} a promise resolved with the PR object from the API
+   */
+  getMergedPrBySha(sha) {
+    const {owner, name} = this.config.vcs.repository
+    const url = `https://api.github.com/repos/${owner}/${name}/pulls?state=closed&sort=updated&direction=desc`
+
+    Logger.log(`About to send GET to ${url}`)
+
+    return fetch(url, getFetchOpts(this.config))
+      .then(resp => resp.json().then(json => ({resp, json})))
+      .then(({resp, json}) => {
+        if (!resp.ok) {
+          throw new Error(`${resp.status}: ${JSON.stringify(json)}`)
+        }
+        return json
+      })
+      .then(prs => prs.find(pr => pr.merge_commit_sha === sha))
+      .then(convertPr)
+      .catch(() => {
+        throw new Error(`Unable to find a merged PR for sha ${sha}`)
+      })
   }
 
   /**

--- a/src/vcs/tests/github.test.js
+++ b/src/vcs/tests/github.test.js
@@ -114,18 +114,30 @@ describe('VCS / GitHub /', () => {
           {
             number: 5,
             body: '#minor#\r\n## Changelog\r\n### Added\r\n- Some kinda cool stuff',
+            user: {
+              login: 'bot1',
+              html_url: 'profile-of-bot1'
+            },
             html_url: 'link-to-pr-5',
             merge_commit_sha: 'sha-1'
           },
           {
             number: 4,
             body: '#minor#\r\n## Changelog\r\n### Added\r\n- Some really cool stuff',
+            user: {
+              login: 'bot2',
+              html_url: 'profile-of-bot2'
+            },
             html_url: 'link-to-pr-4',
             merge_commit_sha: 'sha-2'
           },
           {
             number: 3,
             body: '#minor#\r\n## Changelog\r\n### Added\r\n- Some super cool stuff',
+            user: {
+              login: 'bot3',
+              html_url: 'profile-of-bot3'
+            },
             html_url: 'link-to-pr-3',
             merge_commit_sha: 'sha-3'
           }
@@ -146,6 +158,8 @@ describe('VCS / GitHub /', () => {
 
       it('should resolve with the correct PR', () => {
         expect(resolution).toEqual({
+          author: 'bot2',
+          authorUrl: 'profile-of-bot2',
           description: '#minor#\n## Changelog\n### Added\n- Some really cool stuff',
           number: 4,
           url: 'link-to-pr-4'
@@ -293,6 +307,10 @@ describe('VCS / GitHub /', () => {
       beforeEach(done => {
         const pr = {
           number: 5,
+          user: {
+            login: 'bot',
+            html_url: 'bot-profile'
+          },
           body: '#minor#\r\n## Changelog\r\n### Added\r\n- Some really cool stuff',
           html_url: 'my-link-to-myself',
           head: {
@@ -315,6 +333,8 @@ describe('VCS / GitHub /', () => {
 
       it('should resolve with the correct PR', () => {
         expect(resolution).toEqual({
+          author: 'bot',
+          authorUrl: 'bot-profile',
           description: '#minor#\n## Changelog\n### Added\n- Some really cool stuff',
           number: 5,
           url: 'my-link-to-myself'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4253,6 +4253,16 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
+moment-timezone@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.21.tgz#3cba247d84492174dbf71de2a9848fa13207b845"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Please add a description of your change below.
It will be automatically inserted into the `CHANGELOG.md` file.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
Please remove sections that doesn't apply to your change.

## CHANGELOG
### Added
- `timezone` feature, allowing users to configure the timezone `bumpr` uses when creating dates to add to changelog entries (Fixes [#17](https://github.com/jobsquad/bumpr/issues/17))
- Pull request author to slack message about new published version (Fixes [#20](https://github.com/jobsquad/bumpr/issues/20))
### Changed
- How `bumpr` detects the PR for a merge commit. Instead of parsing commit messages looking for "merge pull request #xyz" it now looks for a PR with a matching `merge_commit_sha` value. This should allow `bumpr` to support any kind of PR merge scheme supported by GitHub (Fixes [#16](https://github.com/jobsquad/bumpr/issues/16))
### Fixed
- Format of the log file generated by `bumpr` to actually match what's documented in `README.md`

