### PR TITLE
Add tag command to just create the git tag

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -49,4 +49,11 @@ program
     withBumpr(bumpr => bumpr.publish())
   })
 
+program
+  .command('tag')
+  .description('create a git tag for the current version (without doing any bumping)')
+  .action(() => {
+    withBumpr(bumpr => bumpr.tag())
+  })
+
 program.parse(process.argv)

--- a/src/bumpr.js
+++ b/src/bumpr.js
@@ -148,6 +148,26 @@ class Bumpr {
   }
 
   /**
+   * Create a git tag for the current version (without any bumping)
+   * @returns {Promise} a promise resolved with the value or rejected on error
+   */
+  tag() {
+    if (get(this.config, 'computed.ci.isPr')) {
+      Logger.log('Not a merge build, skipping bump')
+      return Promise.resolve()
+    }
+
+    // Since we may not have a PR, we'll construct a fake 'info' object
+    const fakeInfo = {
+      modifiedFiles: ['package.json'], // not really, but if we don't put something in here tag won't be pushed
+      scope: 'patch', // must be anything but 'none' so that tag is created
+      version: utils.readJsonFile('package.json').version // current version
+    }
+
+    return this.maybeCreateTag(fakeInfo).then(info => this.maybePushChanges(info))
+  }
+
+  /**
    * Get the contents of the given log file
    * @param {String} filename - the name of the log file
    * @returns {Promise} a promise resolved with the log contents and filename or rejected with an error


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Please add a description of your change below.
It will be automatically inserted into the `CHANGELOG.md` file.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
Please remove sections that doesn't apply to your change.

## CHANGELOG
### Added
- New `tag` CLI command to just create a `git` tag and push it, with no bumping

