### PR TITLE
Support git+ssh url when getting name/owner

### DIFF
--- a/src/vcs/github.js
+++ b/src/vcs/github.js
@@ -86,6 +86,7 @@ class GitHub {
 
       const [owner, name] = str
         .replace('git@github.com:', '')
+        .replace('git+ssh://git@github.com/', '')
         .replace('.git', '')
         .split('/')
 

--- a/src/vcs/tests/github.test.js
+++ b/src/vcs/tests/github.test.js
@@ -548,6 +548,27 @@ describe('VCS / GitHub /', () => {
             })
           })
         })
+
+        describe('when repository is an object with git+ssh url', () => {
+          beforeEach(() => {
+            readFileSync.mockReturnValue(
+              JSON.stringify({
+                repository: {
+                  url: 'git+ssh://git@github.com/jobsquad/bumpr.git'
+                }
+              })
+            )
+
+            github = new GitHub(config)
+          })
+
+          it('should set vcs config as expected', () => {
+            expect(github.config.vcs.repository).toEqual({
+              name: 'bumpr',
+              owner: 'jobsquad'
+            })
+          })
+        })
       })
 
       it('should throw expected error when package.json contents is invalid JSON', () => {


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

## CHANGELOG
### Added
-   Support for `git+ssh://git@github.com/<owner>/<repo>` URL in `package.json`'s `repository.url` attribute to avoid #26 