### PR TITLE
Add support for GitHub Releases (#7)

### DIFF
--- a/.bumprrc.js
+++ b/.bumprrc.js
@@ -9,6 +9,9 @@ module.exports = {
     logging: {
       enabled: true,
       file: '.bumpr-log.json'
+    },
+    release: {
+      enabled: true
     }
   }
 }

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ It will be automatically inserted into the `CHANGELOG.md` file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 Please remove sections that doesn't apply to your change.
 
-## CHANGELOG
+## Changelog
 ### Added
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "commander": "^2.9.0",
     "cosmiconfig": "^5.0.5",
     "lodash": "^4.0.1",
+    "mime-types": "^2.1.22",
     "moment-timezone": "^0.5.21",
     "nlf": "^1.4.1",
     "node-fetch": "^1.3.3",

--- a/src/node-wrappers.js
+++ b/src/node-wrappers.js
@@ -1,6 +1,9 @@
 const {exec} = require('child_process')
-const {writeFile} = require('fs')
+const {createReadStream, readdir, statSync, writeFile} = require('fs')
 const Promise = require('promise')
 
+exports.createReadStream = createReadStream
 exports.exec = Promise.denodeify(exec)
+exports.readdir = Promise.denodeify(readdir)
+exports.statSync = statSync
 exports.writeFile = Promise.denodeify(writeFile)

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,6 +172,10 @@ const utils = {
               enabled: false,
               file: '.bumpr-log.json'
             },
+            release: {
+              enabled: false,
+              artifacts: ''
+            },
             slack: {
               enabled: false,
               env: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4168,11 +4168,23 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
+mime-db@~1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
+
 mime-types@^2.1.12, mime-types@~2.1.17:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@^2.1.22:
+  version "2.1.22"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
+  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
+  dependencies:
+    mime-db "~1.38.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Please add a description of your change below.
It will be automatically inserted into the `CHANGELOG.md` file.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
Please remove sections that doesn't apply to your change.

## CHANGELOG
### Added
- Support for GitHub Release creation during a `bump` or `tag` command ([#7](https://github.com/jobsquad/bumpr/issues/7))
