### PR TITLE
Add support for dependabot PRs

### DIFF
--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -438,6 +438,35 @@ describe('utils', () => {
       expect(utils.getScopeForPr(pr)).toBe('minor')
     })
 
+    it('should return patch when a dependabot pr is made', () => {
+      /* eslint-disable max-len */
+      pr.description = `
+<details>
+<summary>Dependabot commands and options</summary>
+<br />
+
+You can trigger Dependabot actions by commenting on this PR:
+- \`@dependabot rebase\` will rebase this PR
+- \`@dependabot recreate\` will recreate this PR, overwriting any edits that have been made to it
+- \`@dependabot merge\` will merge this PR after your CI passes on it
+- \`@dependabot squash and merge\` will squash and merge this PR after your CI passes on it
+- \`@dependabot cancel merge\` will cancel a previously requested merge and block automerging
+- \`@dependabot reopen\` will reopen this PR if it is closed
+- \`@dependabot close\` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
+- \`@dependabot ignore this major version\` will close this PR and stop Dependabot creating any more for this major version (unless you reopen the PR or upgrade to it yourself)
+- \`@dependabot ignore this minor version\` will close this PR and stop Dependabot creating any more for this minor version (unless you reopen the PR or upgrade to it yourself)
+- \`@dependabot ignore this dependency\` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)
+- \`@dependabot use these labels\` will set the current labels as the default for future PRs for this repo and language
+- \`@dependabot use these reviewers\` will set the current reviewers as the default for future PRs for this repo and language
+- \`@dependabot use these assignees\` will set the current assignees as the default for future PRs for this repo and language
+- \`@dependabot use this milestone\` will set the current milestone as the default for future PRs for this repo and language
+
+You can disable automated security fix PRs for this repo from the [Security Alerts page](https://github.com/all-i-code/bumpr/network/alerts).
+      `
+      /* eslint-enable max-len */
+      expect(utils.getScopeForPr(pr)).toBe('patch')
+    })
+
     describe('when given a maxScope', () => {
       beforeEach(() => {
         pr.description = 'This is my super-cool #minor#'

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,7 @@ const {Logger} = require('./logger')
 
 const GFM_CHECKBOX_CHECKED_REGEX = /(-|\*)\s+\[x\].*?#(\w+)#/gi
 const GFM_CHECKBOX_UNCHECKED_REGEX = /(-|\*)\s+\[\s\].*?#(\w+)#/gi
+const DEPENDABOT_IDENTIFIER = '<summary>Dependabot commands and options</summary>'
 
 /**
  * Walk the properties of an object (recursively) while converting it to a flat representation of the leaves of the
@@ -263,6 +264,16 @@ const utils = {
    * @throws Error if there is not a single, valid scope in the PR description
    */
   getScopeForPr(pr, maxScope = 'major') {
+    // First check for dependabot PR description
+    if (pr.description.includes(DEPENDABOT_IDENTIFIER)) {
+      return utils.getValidatedScope({
+        scope: 'patch',
+        maxScope,
+        prNumber: pr.number,
+        prUrl: pr.url
+      })
+    }
+
     const matches = pr.description.match(/#[A-Za-z]+#/g)
     const prLink = `[PR #${pr.number}](${pr.url})`
 


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

## Changelog
### Added
- Support for parsing `dependabot` PR descriptions (currently treated as `patch`)

