### PR TITLE
Add support for circle-ci (pr not from fork)

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,15 @@ function processEnv(config) {
   /* eslint-disable no-param-reassign */
   config.computed.ci.buildNumber = getEnv(config.ci.env.buildNumber)
   config.computed.ci.prNumber = getEnv(config.ci.env.prNumber, 'false')
+
+  // If no prNumber, check prUrl (some CIs don't have prNumber on branch builds)
+  if (config.computed.ci.prNumber === 'false') {
+    const parts = getEnv(config.ci.env.prUrl, '').split('/')
+    if (parts.length > 1) {
+      config.computed.ci.prNumber = parts[parts.length - 1] || 'false'
+    }
+  }
+
   config.computed.ci.isPr = config.computed.ci.prNumber !== 'false'
   config.computed.ci.branch = getEnv(config.ci.env.branch, 'master')
 
@@ -134,7 +143,8 @@ const utils = {
             env: {
               branch: 'TRAVIS_BRANCH',
               buildNumber: 'TRAVIS_BUILD_NUMBER',
-              prNumber: 'TRAVIS_PULL_REQUEST'
+              prNumber: 'TRAVIS_PULL_REQUEST',
+              prUrl: ''
             },
             gitUser: {
               email: 'bumpr@domain.com',


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Please add a description of your change below.
It will be automatically inserted into the `CHANGELOG.md` file.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
Please remove sections that doesn't apply to your change.

## Changelog
### Added
- Support for Circle-ci PRs from non-forks (where `CIRCLE_PR_NUMBER` isn't set, but rather `CIRLCE_PULL_REQUEST` is set)
