### PR TITLE
Add new changelog.required option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ The following defaults will be used if omitted in `.bumperrc.js`:
     features: {
       changelog: {
         enabled: false,
-        file: 'CHANGELOG.md'
+        file: 'CHANGELOG.md',
+        required: [],
       },
       comments: {
         enabled: false
@@ -321,6 +322,12 @@ Set this value to `true` to enable changelog processing
 
 ##### `features.changelog.file`
 The file to modify when adding the `## CHANGELOG` section of your pull request description (default is `CHANGELOG.md`).
+
+##### `feature.changelog.requires`
+A list of regular expression strings the changelog must match in order for `bumpr check` to pass. For example if you want to ensure your changelog contains ticket links in the form `[####](https://ticket.example.com/####)`, you could set it to:
+```json
+"required": ["\\[\d+]\(https:\\/\\/ticket.example.com\\/\d+\)"],
+```
 
 #### `features.comments`
 `bumpr` has the ability to post comments to the pull request in certain scenarios. Unfortunately, due to the fact

--- a/src/bumpr.js
+++ b/src/bumpr.js
@@ -253,7 +253,7 @@ class Bumpr {
       return {
         author: pr.author,
         authorUrl: pr.authorUrl,
-        changelog: getChangelog ? utils.getChangelogForPr(pr) : '',
+        changelog: getChangelog ? utils.getChangelogForPr(pr, []) : '',
         modifiedFiles: [],
         number: pr.number,
         scope,
@@ -287,7 +287,7 @@ class Bumpr {
         let changelog = ''
         if (getChangelog) {
           return utils.maybePostCommentOnError(this.config, this.vcs, () => {
-            changelog = utils.getChangelogForPr(pr)
+            changelog = utils.getChangelogForPr(pr, get(this.config, 'features.changelog.required', []))
             return {changelog, number: pr.number, scope, url: pr.url}
           })
         }

--- a/src/tests/bumpr.test.js
+++ b/src/tests/bumpr.test.js
@@ -739,7 +739,7 @@ describe('Bumpr', () => {
             })
 
             it('should get the changelog for the given pr', () => {
-              expect(utils.getChangelogForPr).toHaveBeenCalledWith(pr)
+              expect(utils.getChangelogForPr).toHaveBeenCalledWith(pr, [])
             })
 
             it('should resolve with the info', () => {
@@ -1152,7 +1152,7 @@ describe('Bumpr', () => {
           })
 
           it('should get the changelog', () => {
-            expect(utils.getChangelogForPr).toHaveBeenCalledWith('the-pr')
+            expect(utils.getChangelogForPr).toHaveBeenCalledWith('the-pr', [])
           })
 
           it('should return the changelog and scope', () => {
@@ -1160,6 +1160,35 @@ describe('Bumpr', () => {
               changelog: 'the-changelog',
               scope: 'the-scope'
             })
+          })
+        })
+      })
+    })
+
+    describe('when changelog is enabled and required set', () => {
+      beforeEach(() => {
+        bumpr.config.isEnabled.mockImplementation(name => name === 'changelog')
+        bumpr.config.features = {changelog: {enabled: true, required: ['DEV-\\d+']}}
+
+        return bumpr.getOpenPrInfo().then(res => {
+          result = res
+        })
+      })
+
+      describe('the second call to maybePostCommentOnError()', () => {
+        let args
+
+        beforeEach(() => {
+          ;[, args] = utils.maybePostCommentOnError.mock.calls
+        })
+
+        describe('when the wrapped function is called', () => {
+          beforeEach(() => {
+            args[2]()
+          })
+
+          it('should get the changelog and look for required', () => {
+            expect(utils.getChangelogForPr).toHaveBeenCalledWith('the-pr', ['DEV-\\d+'])
           })
         })
       })

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -734,7 +734,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
 
       it('should throw an error', () => {
         expect(() => {
-          utils.getChangelogForPr(pr)
+          utils.getChangelogForPr(pr, [])
         }).toThrow(Error, errorMsg)
       })
     })
@@ -746,7 +746,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
 
       it('should throw an error', () => {
         expect(() => {
-          utils.getChangelogForPr(pr)
+          utils.getChangelogForPr(pr, [])
         }).toThrow(Error, errorMsg)
       })
     })
@@ -758,7 +758,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
 
       it('should throw an error', () => {
         expect(() => {
-          utils.getChangelogForPr(pr)
+          utils.getChangelogForPr(pr, [])
         }).toThrow(Error, 'Multiple changelog sections found. Line 1 and line 4.')
       })
     })
@@ -766,7 +766,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
     describe('when changelog section is present', () => {
       beforeEach(() => {
         pr.description = '##changelog\r\n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
-        changelog = utils.getChangelogForPr(pr)
+        changelog = utils.getChangelogForPr(pr, [])
       })
 
       it('should grab the changelog text', () => {
@@ -777,7 +777,7 @@ You can disable automated security fix PRs for this repo from the [Security Aler
     describe('when changelog section has extra space at the end', () => {
       beforeEach(() => {
         pr.description = '## CHANGELOG    \n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
-        changelog = utils.getChangelogForPr(pr)
+        changelog = utils.getChangelogForPr(pr, [])
       })
 
       it('should grab the changelog text', () => {
@@ -789,11 +789,31 @@ You can disable automated security fix PRs for this repo from the [Security Aler
       beforeEach(() => {
         pr.name = 'Bump foo from 1.2.3 to 1.2.5'
         pr.description = '<summary>Dependabot commands and options</summary>'
-        changelog = utils.getChangelogForPr(pr)
+        changelog = utils.getChangelogForPr(pr, [])
       })
 
       it('should generate changelog from pr name/title', () => {
         expect(changelog).toEqual('### Security\n- [Dependabot] Bump foo from 1.2.3 to 1.2.5')
+      })
+    })
+
+    describe('when required present', () => {
+      it('should err when changelog does not match pattern', () => {
+        pr.description = '##changelog\r\n## Fixes\nFoo, Bar, Baz\n## Features\nFizz, Bang'
+        expect(() => {
+          utils.getChangelogForPr(pr, ['DEV-\\d+'])
+        }).toThrow('Changelog does not match pattern: DEV-\\d+')
+      })
+
+      describe('when changelog matches pattern', () => {
+        beforeEach(() => {
+          pr.description = '##changelog\r\n## Fixes\nFoo, Bar, Baz DEV-1234\n## Features\nFizz, Bang'
+          changelog = utils.getChangelogForPr(pr, ['DEV-\\d+'])
+        })
+
+        it('should grab the changelog text', () => {
+          expect(changelog).toEqual('## Fixes\nFoo, Bar, Baz DEV-1234\n## Features\nFizz, Bang')
+        })
       })
     })
   })

--- a/src/utils.js
+++ b/src/utils.js
@@ -320,9 +320,10 @@ const utils = {
   /**
    * Extract the changelog string from the PR object
    * @param {PullRequest} pr - the PR object
+   * @param {String[]} required - regular expression patterns that changelog must match
    * @returns {String} the changelog of the PR (from the pr description, if one exists, else '')
    */
-  getChangelogForPr(pr) {
+  getChangelogForPr(pr, required) {
     let changelog = ''
 
     // First check for dependabot PR description
@@ -345,6 +346,12 @@ const utils = {
         `See ${link} for details.`
       throw new Error(msg)
     }
+
+    required.forEach(pattern => {
+      if (!new RegExp(pattern).test(changelog)) {
+        throw new Error(`Changelog does not match pattern: ${pattern}`)
+      }
+    })
 
     return changelog
   },


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

## Changelog
### Added
-   New optional `required` option in changelog config to ensure changelog matches a list of regular expressions (ie to ensure proper links to tickets/issues exist)