### PR TITLE
Improve tag/release functionailty

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ The following defaults will be used if omitted in `.bumperrc.js`:
         },
         channels: []
       },
+      tag: {
+        enabled: true,
+      },
       timezone: {
         enabled: false,
         zone: 'Etc/UTC'
@@ -404,6 +407,15 @@ Set this value to `true` to enable the creation of the log file during a `bump`.
 The name of the file to create after a `bump`, the contents of the file will be `json` regardless of the name of
 the file given here.
 
+#### `features.release`
+Create a VCS release after creating a git tag.
+
+##### `features.release.enabled`
+Set this value to `true` to enable creating a release in your VCS after creating a tag.
+
+##### `features.release.artifacts`
+Directory name of any assets you want included in the VCS release that is created.
+
 #### `features.slack`
 Send a message in slack detailing the change that `bumpr` just published. The message will be sent after the `publish`
 command completes.
@@ -424,6 +436,13 @@ The name of the environment variable that holds the URL for your slack webhook.
 An array of channels. The message will be sent to each one individually, using the `channel` property in the slack
 message JSON body. If no channels are given, only a single message will be sent, with no `channel` property, and so
 the default channel for the webhook will be used.
+
+#### `features.tag`
+Create a git tag when bumping versions. By default, `bumpr` will create a git tag when bumping versions. This
+can conflict with some other tools, like `lerna`, and so we allow you to disable this functionality.
+
+##### `features.tag.enabled`
+Set this value to `false` to disable creating a git tag.
 
 #### `features.timezone`
 Report dates in changelog based on a given timezone. By default, `bumpr` uses the UTC timezone to figure out what

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,7 +15,7 @@ function handleError(error) {
 
 function withBumpr(callback) {
   createBumpr()
-    .then(bumpr => callback(bumpr))
+    .then((bumpr) => callback(bumpr))
     .catch(handleError)
 }
 
@@ -25,23 +25,23 @@ program
   .command('check')
   .description('verify an open PR has a version bump comment')
   .action(() => {
-    withBumpr(bumpr => bumpr.check())
+    withBumpr((bumpr) => bumpr.check())
   })
 
 program
   .command('bump')
   .option('-n, --num-extra-commits <num>', 'Number of extra commits made after PR merge commit', 0)
   .description('actually bump the version based on a merged PR')
-  .action(cmd => {
-    withBumpr(bumpr => bumpr.bump(cmd))
+  .action((cmd) => {
+    withBumpr((bumpr) => bumpr.bump(cmd))
   })
 
 program
   .command('info')
   .option('-n, --num-extra-commits <num>', 'Number of extra commits made after PR merge commit', 0)
   .description('collect info from merged PR and write it to log (used for debugging)')
-  .action(cmd => {
-    withBumpr(bumpr => bumpr.info(cmd))
+  .action((cmd) => {
+    withBumpr((bumpr) => bumpr.info(cmd))
   })
 
 program
@@ -52,28 +52,29 @@ program
     // this will allow CI scripts to do things like:
     // $ bumpr is-pr && echo "A PR build"
     // $ bumpr is-pr || echo "A merge build"
-    withBumpr(bumpr => process.exit(bumpr.isPr() ? 0 : 1))
+    withBumpr((bumpr) => process.exit(bumpr.isPr() ? 0 : 1))
   })
 
 program
   .command('log <key>')
   .description(`Output the given key from the ${name} log file`)
-  .action(key => {
-    withBumpr(bumpr => bumpr.log(key).then(value => console.log(value)))
+  .action((key) => {
+    withBumpr((bumpr) => bumpr.log(key).then((value) => console.log(value)))
   })
 
 program
   .command('publish')
   .description('actually publish the newly bumped version')
   .action(() => {
-    withBumpr(bumpr => bumpr.publish())
+    withBumpr((bumpr) => bumpr.publish())
   })
 
 program
   .command('tag')
+  .option('-i, --info-file <file>', 'File holding PR info that triggered change', '')
   .description('create a git tag for the current version (without doing any bumping)')
-  .action(() => {
-    withBumpr(bumpr => bumpr.tag())
+  .action((cmd) => {
+    withBumpr((bumpr) => bumpr.tag(cmd))
   })
 
 program.parse(process.argv)

--- a/src/utils.js
+++ b/src/utils.js
@@ -194,6 +194,9 @@ const utils = {
               },
               channels: [],
             },
+            tag: {
+              enabled: true,
+            },
             timezone: {
               enabled: false,
               zone: 'Etc/UTC',


### PR DESCRIPTION


## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

## Changelog
### Added
- The ability to disable tag creation in config
- The ability to pass PR info into `bumpr tag` command with the `--info-file` option
