### PR TITLE
Fix workspace query handling

### DIFF
--- a/src/bumpr.js
+++ b/src/bumpr.js
@@ -24,7 +24,8 @@ const {cloneDeep, get, truncate} = _
  */
 function getPackages() {
   Logger.log('About to query npm for workspace info')
-  return exec('npm query .workspace', {cwd: '.', maxBuffer: 1024 * 1024}).then((output) => {
+  return exec('npm query .workspace', {cwd: '.', maxBuffer: 1024 * 1024}).then(({stdout}) => {
+    const output = stdout.trim()
     Logger.log(`Output from "npm query .workspace": ${truncate(output, {length: 50})}`)
     const packages = JSON.parse(output).map((entry) => entry.location)
     return packages.length === 0 ? ['.'] : packages

--- a/src/package.js
+++ b/src/package.js
@@ -1,19 +1,9 @@
 import {readFileSync} from 'fs'
-import _ from 'lodash'
 import path from 'path'
 import * as url from 'url'
 
 const dirname = url.fileURLToPath(new URL('.', import.meta.url))
-const pathToPkg = path.join(dirname, '..', 'package.json')
-if (process.env.VERBOSE) {
-  console.log(`Path to package.json: ${pathToPkg}`)
-}
-const contents = readFileSync(pathToPkg, {encoding: 'utf-8'})
-if (process.env.VERBOSE) {
-  console.log(`Contents of package.json: ${_.truncate(contents, {length: 50})}`)
-}
-
-const pkg = JSON.parse(contents)
+const pkg = JSON.parse(readFileSync(path.join(dirname, '..', 'package.json'), {encoding: 'utf-8'}))
 
 export const {name, version} = pkg
 export default pkg

--- a/src/tests/bumpr.test.js
+++ b/src/tests/bumpr.test.js
@@ -35,7 +35,8 @@ class FileNotFoundError extends Error {
 }
 
 function setupPkgs(pkgs = []) {
-  exec.mockReturnValueOnce(Promise.resolve(JSON.stringify(pkgs)))
+  const response = {stdout: JSON.stringify(pkgs)}
+  exec.mockReturnValueOnce(Promise.resolve(response))
 }
 
 /**


### PR DESCRIPTION
## Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [x] #patch#
- [ ] #minor#
- [ ] #major#

## Changelog
### Fixed
- Processing of response from `npm query .workspace`



<!-- END CHANGELOG -->
